### PR TITLE
NO-TICKET: proper exposition of typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "dataway",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/dataway.cjs.js",
   "module": "dist/dataway.esm.js",
   "browser": "dist/dataway.umd.js",
+  "types": "dist/main.d.ts",
   "license": "MIT",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
What this PR does / why we need it:

typings file was not properly exposed in the package.json configuration, so TS project using this add trouble, Dataway types being resolved as any.
