### PR TITLE
NO-TICKET: return typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataway",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/dataway.cjs.js",
   "module": "dist/dataway.esm.js",
   "browser": "dist/dataway.umd.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,16 +181,16 @@ export class Success<L, A> {
   }
 }
 
-export const notAsked = <L, A>(): Dataway<L, A> => {
+export const notAsked = <L, A>(): NotAsked<L, A> => {
   return new NotAsked();
 };
-export const loading = <L, A>(): Dataway<L, A> => {
+export const loading = <L, A>(): Loading<L, A> => {
   return new Loading();
 };
-export const failure = <L, A>(l: L): Dataway<L, A> => {
+export const failure = <L, A>(l: L): Failure<L, A> => {
   return new Failure(l);
 };
-export const success = <L, A>(a: A): Dataway<L, A> => {
+export const success = <L, A>(a: A): Success<L, A> => {
   return new Success(a);
 };
 


### PR DESCRIPTION
What this PR does / why we need it:
dataway function creation:

- notAsked
- loading
- failure
- success

 returned a to much broad type (alway Dataway) instead of:

- NotAsked
- Loading
- Failure
- Success

resulting in consumer code to have issue when trying to match Dataway onto (NotAsked,Loading,Failure,Success)

when it should be an exact match or the other way

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #