### PR TITLE
NO-TICKET: fromNullable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,12 @@ export function success<E = never, A = never>(success: A): Dataway<E, A> {
   return { _tag: 'Success', success };
 }
 
+export function fromNullable<E = never, A = never>(
+  successValue: A | null | undefined,
+): Dataway<E, A> {
+  return successValue == null ? notAsked : success(successValue);
+}
+
 export function isNotAsked<L, A>(monadA: Dataway<L, A>): monadA is NotAsked {
   return monadA._tag === 'NotAsked';
 }

--- a/test/remotedata.test.ts
+++ b/test/remotedata.test.ts
@@ -13,6 +13,7 @@ import {
   append,
   fold,
   fromEither,
+  fromNullable,
   isFailure,
   isSuccess,
 } from '../src/main';
@@ -205,6 +206,21 @@ describe('Dataway', () => {
 
       expect(isSuccess(data)).toEqual(true);
       expect(content).toEqual(myValue);
+    });
+  });
+
+  describe('fromNullable', () => {
+    it('create NotAsked from null', () => {
+      expect(fromNullable(null)).toEqual(notAsked);
+    });
+    it('create NotAsked from undefined', () => {
+      expect(fromNullable(undefined)).toEqual(notAsked);
+    });
+    it('create Success<E, A> from any value different from null and undefined', () => {
+      expect(fromNullable('')).toEqual(success(''));
+      expect(fromNullable('test')).toEqual(success('test'));
+      expect(fromNullable([])).toEqual(success([]));
+      expect(fromNullable({})).toEqual(success({}));
     });
   });
 });


### PR DESCRIPTION
What this PR does / why we need it:

add a `fromNullable` function that produce either a `NotAsked` or a `Success` value

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #