### PR TITLE
Make fold pipeable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -304,8 +304,7 @@ export const append = <E, A, B>(
  *   () => "<span>Search initiated, awesome code snippets incomings !</span>",
  *   error => `<span>ho no ! ${error} did happen, please retry</span>`,
  *   results => `<ul>${results.map(result => `<li>${result}</li>`)}</ul>`,
- *   searchResult
- * );
+ * )(searchResult);
  * ```
  * @typeparam E the error type you expect
  * @typeparam A the success type you expect
@@ -314,15 +313,13 @@ export const append = <E, A, B>(
  * @param onLoading
  * @param onFailure
  * @param onSuccess
- * @param monadA
  */
 export const fold = <E, A, B>(
   onNotAsked: () => B,
   onLoading: () => B,
   onFailure: (failure: E) => B,
   onSuccess: (success: A) => B,
-  monadA: Dataway<E, A>,
-): B => {
+) => (monadA: Dataway<E, A>): B => {
   switch (monadA._tag) {
     case 'NotAsked':
       return onNotAsked();

--- a/test/remotedata.test.ts
+++ b/test/remotedata.test.ts
@@ -154,10 +154,10 @@ describe('Dataway', () => {
     const onError = (error: string): string => error;
     const onSuccess = (value: string): string => value.length.toString();
     expect(
-      fold(notaskedvalue, loadingvalue, onError, onSuccess, notAsked),
+      fold(notaskedvalue, loadingvalue, onError, onSuccess)(notAsked),
     ).toEqual('notAsked');
     expect(
-      fold(notaskedvalue, loadingvalue, onError, onSuccess, loading),
+      fold(notaskedvalue, loadingvalue, onError, onSuccess)(loading),
     ).toEqual('loading');
     expect(
       fold(
@@ -165,11 +165,12 @@ describe('Dataway', () => {
         loadingvalue,
         onError,
         onSuccess,
+      )(
         failure('error loading resource'),
       ),
     ).toEqual('error loading resource');
     expect(
-      fold(notaskedvalue, loadingvalue, onError, onSuccess, success('axel')),
+      fold(notaskedvalue, loadingvalue, onError, onSuccess)(success('axel')),
     ).toEqual('4');
   });
 
@@ -184,8 +185,7 @@ describe('Dataway', () => {
         () => 'loading',
         error => error,
         value => value,
-        data,
-      );
+      )(data);
 
       expect(isFailure(data)).toEqual(true);
       expect(content).toEqual(myError);
@@ -201,8 +201,7 @@ describe('Dataway', () => {
         () => 'loading',
         error => error,
         value => value,
-        data,
-      );
+      )(data);
 
       expect(isSuccess(data)).toEqual(true);
       expect(content).toEqual(myValue);


### PR DESCRIPTION
`fold`s from fp-ts are pipeable because they return a function that, given the monad, execute the fold : 
```
fold: (onNone, onSome) => Option => Result
```

dataway's `fold` is not pipeable because its signature is 
```
fold: (onNotAsked, onLoading, onFailure, onSuccess, Dataway) => Result
```

This PR (breaking) fixes this.
