### PR TITLE
v3 - Pipeable functions - BREAKING CHANGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ const view = state => {
     () => "<p>Click on the load button</p>",
     () => "<p>Loading</p>",
     error => `<p>something wrong did happen : ${error}</p>`,
-    success => `<ul>${success.map(post => `<li>${post.title}</li>`)}</ul>`,
-    state
-  );
+    success => `<ul>${success.map(post => `<li>${post.title}</li>`)}</ul>`
+  )(state);
 };
 
 const setState = stateManager(view, notAsked);
@@ -131,9 +130,9 @@ const render = dataway => fold(
   () => "<p>Click on the load button</p>",
   () => "<p>Loading</p>",
   error => `<p>something wrong did happen : ${error}</p>`,
-  success => `<p>${success}</p>`,
-  dataway
-);
+  success => `<p>${success}</p>`
+)(dataway);
+
 render(success('Mr Wilson'));
 // => <p>Mr Wilson</p>
 render(failure('Ooops failed to fetch Mr Wilson data'));

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,36 +254,6 @@ export const map3 = <E, A, B, C, D>(
   dataway.ap(dataway.ap(dataway.map(functorA, f), functorB), functorC);
 
 /**
- * if both argument are `Success` return a tuple containing both values wrapped in a `Success`
- *
- * if not, the leftmost argument with the highest priority as defined bellow will be returned
- *
- * `Failure` being the highest priority, `Loading` being the lowest
- *
- * `Failure -> NotAsked -> Loading`
- *
- * ```
- * import { append, failure, success } from  'dataway';
- *
- * append(success('a'), success('b')) === success(['a', 'b']);
- * append(failure('a'), success('b')) === failure('a');
- * append(failure('a'), failure('b')) === failure('a');
- * ```
- *
- * @param functorA
- * @param functorB
- */
-export const append = <E, A, B>(
-  functorA: Dataway<E, A>,
-  functorB: Dataway<E, B>,
-): Dataway<E, [A, B]> => {
-  return dataway.ap(
-    dataway.map(functorA, (a: A) => (b: B): [A, B] => [a, b]),
-    functorB,
-  );
-};
-
-/**
  * Fold is the only way to attempt to safely extract the data,
  * because it force you to consider the four variations of the dataway state.
  * The following example demonstrate how useful this is when trying to render a

--- a/test/remotedata.test.ts
+++ b/test/remotedata.test.ts
@@ -11,7 +11,6 @@ import {
   map,
   map2,
   map3,
-  append,
   fold,
   fromEither,
   fromNullable,
@@ -97,17 +96,6 @@ describe('Dataway', () => {
         expect(map3(f, success('abc'), failure('xyz'), success('ghi'))).toEqual(
           failure('xyz'),
         );
-      });
-    });
-
-    describe('append', () => {
-      it('return success if both Dataway are success', () => {
-        expect(append(success('abc'), success('def'))).toEqual(
-          success(['abc', 'def']),
-        );
-      });
-      it('return failure if one Dataway is a failure', () => {
-        expect(append(success('abc'), failure('xyz'))).toEqual(failure('xyz'));
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2278,7 +2278,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.17.13, lodash@^4.17.11:
+lodash@4.17.13, lodash@^4.17.11, lodash@^4.17.15:
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
   integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==


### PR DESCRIPTION
What this PR does / why we need it: This PR bundles some changes making `fold` pipeable, removing `append` from the function pool, and updating documentation.
