### PR TITLE
Add repository in packagefile

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
   },
   "dependencies": {
     "fp-ts": "^2.0.5"
-  }
+  },
+  "repository": "github:iadvize/dataway"
 }


### PR DESCRIPTION
What this PR does / why we need it:

There's no link to github repository in the npm page  package sidepanel.
