### PR TITLE
No-TICKET: fold hotfix following history rewrite mixup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -275,7 +275,7 @@ export const map3 = <E, A, B, C, D>(
  *   () => "<span>Search initiated, awesome code snippets incomings !</span>",
  *   error => `<span>ho no ! ${error} did happen, please retry</span>`,
  *   results => `<ul>${results.map(result => `<li>${result}</li>`)}</ul>`,
- *   searchResult
+ *   )(searchResult)
  * );
  * ```
  * @typeparam E the error type you expect
@@ -285,15 +285,13 @@ export const map3 = <E, A, B, C, D>(
  * @param onLoading
  * @param onFailure
  * @param onSuccess
- * @param monadA
  */
 export const fold = <E, A, B>(
   onNotAsked: () => B,
   onLoading: () => B,
   onFailure: (failure: E) => B,
   onSuccess: (success: A) => B,
-  monadA: Dataway<E, A>,
-): B => {
+) => (monadA: Dataway<E, A>): B => {
   switch (monadA._tag) {
     case 'NotAsked':
       return onNotAsked();
@@ -345,9 +343,9 @@ export const getEq = <E, A>(EE: Eq<E>, EA: Eq<A>): Eq<Dataway<E, A>> => {
       }
 
       return false;
-    }
-  }
-}
+    },
+  };
+};
 export const dataway: Monad2<URI> = {
   /**
    * @ignore

--- a/test/remotedata.test.ts
+++ b/test/remotedata.test.ts
@@ -144,22 +144,18 @@ describe('Dataway', () => {
     const onError = (error: string): string => error;
     const onSuccess = (value: string): string => value.length.toString();
     expect(
-      fold(notaskedvalue, loadingvalue, onError, onSuccess, notAsked),
+      fold(notaskedvalue, loadingvalue, onError, onSuccess)(notAsked),
     ).toEqual('notAsked');
     expect(
-      fold(notaskedvalue, loadingvalue, onError, onSuccess, loading),
+      fold(notaskedvalue, loadingvalue, onError, onSuccess)(loading),
     ).toEqual('loading');
     expect(
-      fold(
-        notaskedvalue,
-        loadingvalue,
-        onError,
-        onSuccess,
+      fold(notaskedvalue, loadingvalue, onError, onSuccess)(
         failure('error loading resource'),
       ),
     ).toEqual('error loading resource');
     expect(
-      fold(notaskedvalue, loadingvalue, onError, onSuccess, success('axel')),
+      fold(notaskedvalue, loadingvalue, onError, onSuccess)(success('axel')),
     ).toEqual('4');
   });
 
@@ -174,8 +170,7 @@ describe('Dataway', () => {
         () => 'loading',
         error => error,
         value => value,
-        data,
-      );
+      )(data);
 
       expect(isFailure(data)).toEqual(true);
       expect(content).toEqual(myError);
@@ -191,8 +186,7 @@ describe('Dataway', () => {
         () => 'loading',
         error => error,
         value => value,
-        data,
-      );
+      )(data);
 
       expect(isSuccess(data)).toEqual(true);
       expect(content).toEqual(myValue);
@@ -232,13 +226,11 @@ describe('Dataway', () => {
     });
 
     it('returns true if same failure value', () => {
-      expect(E.equals(failure(1), failure(1)))
-        .toEqual(true);
+      expect(E.equals(failure(1), failure(1))).toEqual(true);
     });
 
     it('returns false if different failure value', () => {
-      expect(E.equals(failure(1), failure(2)))
-        .toEqual(false);
+      expect(E.equals(failure(1), failure(2))).toEqual(false);
     });
 
     it('returns true if same success value', () => {


### PR DESCRIPTION
What this PR does / why we need it:
hotfix, fold signature update was missing following history rewrite
