### PR TITLE
misc(): upgradeFPTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^3.6.2"
   },
   "dependencies": {
-    "fp-ts": "^2.0.5"
+    "fp-ts": "^2.1.2"
   },
   "repository": "github:iadvize/dataway"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,10 +1209,10 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-fp-ts@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.0.5.tgz#9560d8a6a4f53cbda9f9b31ed8d1458e41939e07"
-  integrity sha512-opI5r+rVlpZE7Rhk0YtqsrmxGkbIw0dRNqGca8FEAMMnjomXotG+R9QkLQg20onx7R8qhepAn4CCOP8usma/Xw==
+fp-ts@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.1.2.tgz#6acab50af1ac5044ebd6e6c38d83e3b5905a7982"
+  integrity sha512-oOZ/gc+lxTSfKRk6vnAAie2HQTWMH7yhaIM0+gW8fAi4JAiPT/OmEpW5ps3VuapPGNqnZ++4p56hv3PEd1qUFg==
 
 fragment-cache@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
What this PR does / why we need it:
fp-ts fixed sequenceT and sequenceS typing in 2.1.1 (https://github.com/gcanti/fp-ts/blob/master/CHANGELOG.md#211) for Kind4 ( that we use). With previous version, following code would break :
```
import { dataway } from 'dataway';

import { sequenceT } from 'fp-ts/lib/Apply';
import { sequenceS } from 'fp-ts/es6/Apply';

export const sequenceTofDataway = sequenceT(dataway);

export const sequenceSofDataway = sequenceS(dataway);
```
