### PR TITLE
NO-TICKET: fix notAsked, loading, failure, success signatures

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -81,15 +81,15 @@ export interface Success<A> {
  */
 export type Dataway<E, A> = NotAsked | Loading | Failure<E> | Success<A>;
 
-export const notAsked: Dataway<never, never> = { _tag: 'NotAsked' };
+export const notAsked: NotAsked = { _tag: 'NotAsked' };
 
-export const loading: Dataway<never, never> = { _tag: 'Loading' };
+export const loading: Loading = { _tag: 'Loading' };
 
-export function failure<E = never, A = never>(failure: E): Dataway<E, A> {
+export function failure<E = never>(failure: E): Failure<E> {
   return { _tag: 'Failure', failure };
 }
 
-export function success<E = never, A = never>(success: A): Dataway<E, A> {
+export function success<A = never>(success: A): Success<A> {
   return { _tag: 'Success', success };
 }
 


### PR DESCRIPTION
What this PR does / why we need it:

This use the corresponding types for `notAsked`, `loading`, `failure`, `success` signatures instead of the generic `Dataway<X, Y>`

Which issue(s) this PR fixes:

I encountered this error 
![image](https://user-images.githubusercontent.com/748586/71521366-c7d9e800-28c0-11ea-9963-0957445e8212.png)

`status` here should absolutely be `NotAsked` not `notAsked` is type like a more generic value, so TS can not succeed the type check


